### PR TITLE
Dedupe events already processed by the frontend (fixes #6)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -146,12 +146,18 @@ class App extends React.Component {
      * used it personally) would be better in prod but again maybe its also
      * overkill. Maybe even better to reduce on the server side...?
      */
+    const seenEventIds = new Set(); // ignore events we've already accumulated
     this.storage = storage();
-    this.storage.subscribe((events) =>
+    this.storage.subscribe((events) => {
+      const newEvents = events.filter(
+        (event) => !seenEventIds.has(event.eventId)
+      );
+      events.forEach((event) => seenEventIds.add(event.eventId));
+
       this.setState((prevState) => ({
-        comments: events.reduce(reduceEvents, [...prevState.comments]),
-      }))
-    );
+        comments: newEvents.reduce(reduceEvents, [...prevState.comments]),
+      }));
+    });
   }
 
   handleAddUpvote(commentId) {


### PR DESCRIPTION
This avoids duplicated data when the event stream reconnects (which can happen for any number of reasons). Maybe a cleaner long term solution would be to hide this away in the "storage" abstraction